### PR TITLE
Add G84 command

### DIFF
--- a/femto/LaserPath.py
+++ b/femto/LaserPath.py
@@ -110,7 +110,7 @@ class LaserPath(WaveguideParameters):
     @property
     def length(self) -> float:
         x, y, z = self.path3d
-        return float(np.sum(np.sqrt(np.diff(x)**2 + np.diff(y)**2 + np.diff(z)**2)))
+        return float(np.sum(np.sqrt(np.diff(x) ** 2 + np.diff(y) ** 2 + np.diff(z) ** 2)))
 
     def add_path(self, x: np.ndarray, y: np.ndarray, z: np.ndarray, f: np.ndarray, s: np.ndarray):
         """
@@ -250,8 +250,7 @@ def _example():
             .sin_mzi((-1) ** (index + 1) * wg.dy_bend) \
             .linear(increment)
         wg.end()
-
-    print(wg.length)
+        print(wg.length)
 
     # Plot
     fig = plt.figure()

--- a/femto/Marker.py
+++ b/femto/Marker.py
@@ -42,7 +42,7 @@ class Marker(Waveguide):
         if self._x.size != 0:
             raise ValueError('Coordinate matrix is not empty. Cannot start a new waveguide in this point.')
         if speedpos is None:
-            speedpos = self.speedpos
+            speedpos = self.speed_pos
 
         x0, y0, z0 = init_pos
         f0 = np.asarray(speedpos, dtype=np.float32)

--- a/femto/PGMCompiler.py
+++ b/femto/PGMCompiler.py
@@ -221,7 +221,7 @@ class PGMCompiler(GcodeParameters):
 
     def deactivate_axis_rotation(self):
         self.comment('DEACTIVATE AXIS ROTATION')
-        self._instructions.append('LINEAR X0 Y0 Z0\n')
+        self._instructions.append(f'LINEAR X{0.0:.6f} Y{0.0:.6f} Z{0.0:.6f} F{self.speed_pos:.6f}\n')
         self._instructions.append(f'G84 X Y\n')
 
     @contextmanager

--- a/femto/PGMCompiler.py
+++ b/femto/PGMCompiler.py
@@ -225,6 +225,19 @@ class PGMCompiler(GcodeParameters):
         self._instructions.append(f'G84 X Y\n')
 
     @contextmanager
+    def axis_rotation(self):
+        self.comment('ACTIVATE AXIS ROTATION')
+        self._instructions.append(f'LINEAR X{0.0:.6f} Y{0.0:.6f} Z{0.0:.6f} F{self.speed_pos:.6f}\n')
+        self._instructions.append(f'G84 X Y\n')
+        self._instructions.append(f'G84 X Y F{self.aerotech_angle}\n\n')
+        try:
+            yield
+        finally:
+            self.comment('DEACTIVATE AXIS ROTATION')
+            self._instructions.append(f'LINEAR X{0.0:.6f} Y{0.0:.6f} Z{0.0:.6f} F{self.speed_pos:.6f}\n')
+            self._instructions.append(f'G84 X Y\n')
+
+    @contextmanager
     def for_loop(self, var: str, num: int):
         """
         Context manager that manages a FOR loop in a G-Code file.

--- a/femto/PGMCompiler.py
+++ b/femto/PGMCompiler.py
@@ -51,7 +51,7 @@ class PGMCompiler(GcodeParameters):
         self.header()
         self.dwell(1.0)
         if self.aerotech_angle:
-            self._enter_axis_rotation()
+            self._enter_axis_rotation(angle=self.aerotech_angle)
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
@@ -559,11 +559,16 @@ class PGMCompiler(GcodeParameters):
             file = Path(filename)
         return file
 
-    def _enter_axis_rotation(self):
+    def _enter_axis_rotation(self, angle: float = None):
         self.comment('ACTIVATE AXIS ROTATION')
         self._instructions.append(f'LINEAR X{0.0:.6f} Y{0.0:.6f} Z{0.0:.6f} F{self.speed_pos:.6f}\n')
         self._instructions.append(f'G84 X Y\n')
-        self._instructions.append(f'G84 X Y F{self.aerotech_angle}\n\n')
+
+        if angle is None:
+            return
+
+        angle = float(angle % 360)
+        self._instructions.append(f'G84 X Y F{angle}\n\n')
 
     def _exit_axis_rotation(self):
         self.comment('DEACTIVATE AXIS ROTATION')

--- a/femto/PGMCompiler.py
+++ b/femto/PGMCompiler.py
@@ -50,6 +50,8 @@ class PGMCompiler(GcodeParameters):
         """
         self.header()
         self.dwell(1.0)
+        if self.aerotech_angle:
+            self.activate_axis_rotation()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
@@ -58,6 +60,10 @@ class PGMCompiler(GcodeParameters):
 
         :return: None
         """
+
+        if self.aerotech_angle:
+            self.deactivate_axis_rotation()
+            self._instructions.append('\n')
         self.go_init()
         self.close()
 
@@ -208,6 +214,16 @@ class PGMCompiler(GcodeParameters):
         self._instructions.append(f'LINEAR {args}\n')
         self.dwell(self.long_pause)
 
+    def activate_axis_rotation(self):
+        self.deactivate_axis_rotation()
+        self.comment('ACTIVATE AXIS ROTATION')
+        self._instructions.append(f'G84 X Y F{self.aerotech_angle}\n\n')
+
+    def deactivate_axis_rotation(self):
+        self.comment('DEACTIVATE AXIS ROTATION')
+        self._instructions.append('LINEAR X0 Y0 Z0\n')
+        self._instructions.append(f'G84 X Y\n')
+
     @contextmanager
     def for_loop(self, var: str, num: int):
         """
@@ -282,6 +298,8 @@ class PGMCompiler(GcodeParameters):
 
         :param filename: Name of the file that have to be loaded.
         :type filename: str
+        :param task_id: ID of the task associated to the process.
+        :type task_id: int
         :return: None
         """
         file = self._parse_filepath(filename, extension='pgm')
@@ -294,6 +312,8 @@ class PGMCompiler(GcodeParameters):
 
         :param filename: Name of the file to remove.
         :type filename: str
+        :param task_id: ID of the task associated to the process.
+        :type task_id: int
         :return: None
         """
         file = self._parse_filepath(filename, extension='pgm')
@@ -325,6 +345,8 @@ class PGMCompiler(GcodeParameters):
 
         :param filename: Name of the file to call.
         :type filename: str
+        :param task_id: ID of the task associated to the process.
+        :type task_id: int
         :return: None
         """
         file = self._parse_filepath(filename)
@@ -332,7 +354,7 @@ class PGMCompiler(GcodeParameters):
             raise FileNotFoundError(f'{file} not loaded. Cannot load it.')
         self._instructions.append(f'PROGRAM {task_id} BUFFEREDRUN "{file}"\n')
 
-    def chiamatutto(self, filenames: List[str], task_id: List[int] = [0]):
+    def chiamatutto(self, filenames: List[str], task_id: List[int] = 0):
         for (fpath, t_id) in zip_longest(listcast(filenames), listcast(task_id), fillvalue=0):
             _, fn = os.path.split(fpath)
             self.load_program(fpath, t_id)
@@ -344,9 +366,9 @@ class PGMCompiler(GcodeParameters):
     def write(self, points: np.ndarray):
         """
         The function convert the quintuple (X,Y,Z,F,S) to G-Code instructions. The (X,Y,Z) coordinates are
-        transformed using the transformation matrix that takes into account the rotation of a given angle and the
-        homothety to compensate the (effective) refractive index different from 1. Moreover, if the warp_flag is True
-        the points are compensated along the z-direction.
+        transformed using the transformation matrix that takes into account the rotation of a given rotation_angle
+        and the homothety to compensate the (effective) refractive index different from 1. Moreover, if the warp_flag
+        is True the points are compensated along the z-direction.
 
         The transformed points are then parsed together with the feed rate and shutter state coordinate to produce
         the LINEAR movements.
@@ -415,9 +437,15 @@ class PGMCompiler(GcodeParameters):
             pgm_filename = filename
         else:
             pgm_filename = self.filename
+
         # if not present in the filename, add the proper file extension
         if not pgm_filename.endswith('.pgm'):
             pgm_filename += '.pgm'
+
+        if self.export_dir:
+            if not os.path.exists(self.export_dir):
+                os.makedirs(self.export_dir)
+            pgm_filename = os.path.join(self.export_dir, pgm_filename)
 
         # write instruction to file
         with open(pgm_filename, 'w') as f:
@@ -447,7 +475,7 @@ class PGMCompiler(GcodeParameters):
 
     def t_matrix(self, dim: int = 3) -> np.ndarray:
         """
-        Given the rotation angle and the rifraction index, the function compute the transformation matrix as
+        Given the rotation rotation_angle and the rifraction index, the function compute the transformation matrix as
         composition of rotatio matrix (RM) and a homothety matrix (SM).
 
         :param dim: Dimension of the transformation matrix. The default is 3.
@@ -457,8 +485,8 @@ class PGMCompiler(GcodeParameters):
 
         :raise ValueError: Dimension not valid
         """
-        RM = np.array([[np.cos(self.angle), -np.sin(self.angle), 0],
-                       [np.sin(self.angle), np.cos(self.angle), 0],
+        RM = np.array([[np.cos(self.rotation_angle), -np.sin(self.rotation_angle), 0],
+                       [np.sin(self.rotation_angle), np.cos(self.rotation_angle), 0],
                        [0, 0, 1]])
         SM = np.array([[1, 0, 0],
                        [0, 1, 0],
@@ -535,7 +563,7 @@ class PGMCompiler(GcodeParameters):
 
 
 class PGMTrench(PGMCompiler):
-    def __init__(self, param: dict, trench_columns: TrenchColumn):
+    def __init__(self, param: dict, trench_columns: List[TrenchColumn]):
         super().__init__(param)
         self.trench_columns = listcast(trench_columns)
         self._param = param
@@ -552,77 +580,81 @@ class PGMTrench(PGMCompiler):
         :type dirname: str
         :return: None
         """
-        t_list = []
+
         for col_idx, col in enumerate(self.trench_columns):
-            self._instructions = deque()
-            col_pgm = os.path.join(os.getcwd(), dirname, f'FARCALL{col_idx + 1:03}.pgm')
-            t_list.append(os.path.join(col.base_folder, f'FARCALL{col_idx + 1:03}.pgm'))
-            col_dir = os.path.join(os.getcwd(), dirname, f'trenchCol{col_idx + 1:03}')
+            # Prepare directories for export .pgm files
+            col_dir = os.path.join(os.getcwd(), self.export_dir, dirname, f'trenchCol{col_idx + 1:03}')
             os.makedirs(col_dir, exist_ok=True)
+
+            # Export walls and floors .pgm scripts
             for i, trench in enumerate(col):
                 filename = os.path.join(col_dir, f'trench{i + 1:03}')
-                self._export_path(filename, trench, f=col.speed)
+                self._export_path(filename, trench, speed=col.speed)
 
-            self.header()
-            self.dwell(1.0)
-            self.dvar(['ZCURR'])
+            # Export FARCALL for each trench column
+            col_param = self._param.copy()
+            col_param['filename'] = os.path.join(os.getcwd(), self.export_dir, dirname, f'FARCALL{col_idx + 1:03}.pgm')
+            with PGMCompiler(col_param) as G:
+                G.dvar(['ZCURR'])
 
-            for nbox in range(col.nboxz):
-                for t_index, trench in enumerate(col):
-                    # load filenames (wall/floor)
-                    wall_filename = f'trench{t_index + 1:03}_wall.pgm'
-                    floor_filename = f'trench{t_index + 1:03}_floor.pgm'
-                    wall_path = os.path.join(col.base_folder, f'trenchCol{col_idx + 1:03}', wall_filename)
-                    floor_path = os.path.join(col.base_folder, f'trenchCol{col_idx + 1:03}', floor_filename)
+                for nbox in range(col.nboxz):
+                    for t_index, trench in enumerate(col):
+                        # load filenames (wall/floor)
+                        wall_filename = f'trench{t_index + 1:03}_wall.pgm'
+                        floor_filename = f'trench{t_index + 1:03}_floor.pgm'
+                        wall_path = os.path.join(col.base_folder, f'trenchCol{col_idx + 1:03}', wall_filename)
+                        floor_path = os.path.join(col.base_folder, f'trenchCol{col_idx + 1:03}', floor_filename)
 
-                    x0, y0 = trench.block.exterior.coords[0]
-                    z0 = (nbox * col.h_box - col.z_off) / super().neff
-                    self.comment(f'+--- COLUMN #{col_idx + 1}, TRENCH #{t_index + 1} LEVEL {nbox + 1} ---+')
+                        x0, y0 = trench.block.exterior.coords[0]
+                        z0 = (nbox * col.h_box - col.z_off) / super().neff
+                        G.comment(f'+--- COLUMN #{col_idx + 1}, TRENCH #{t_index + 1} LEVEL {nbox + 1} ---+')
 
-                    # WALL
-                    self.load_program(wall_path)
-                    self.instruction(f'MSGDISPLAY 1, "COL {col_idx + 1:03}, TR {t_index + 1:03}, LV {nbox + 1:03}, '
-                                     f'W"\n')
-                    self.shutter('OFF')
-                    if col.u:
-                        self.instruction(f'LINEAR U{col.u[0]:.6f}')
-                    self.move_to([x0 - self.new_origin[0], y0 - self.new_origin[1], z0], speedpos=col.speed_closed)
+                        # WALL
+                        G.load_program(wall_path)
+                        G.instruction(
+                                f'MSGDISPLAY 1, "COL {col_idx + 1:03}, TR {t_index + 1:03}, LV {nbox + 1:03}, W"\n')
+                        G.shutter('OFF')
+                        if col.u:
+                            G.instruction(f'LINEAR U{col.u[0]:.6f}')
+                        G.move_to([x0 - self.new_origin[0], y0 - self.new_origin[1], z0], speedpos=col.speed_closed)
 
-                    self.instruction(f'$ZCURR = {z0:.6f}')
-                    self.shutter('ON')
-                    with self.repeat(col.n_repeat):
-                        self.farcall(wall_filename)
-                        self.instruction(f'$ZCURR = $ZCURR + {col.deltaz / super().neff:.6f}')
-                        self.instruction('LINEAR Z$ZCURR')
-                    self.remove_program(wall_filename)
+                        G.instruction(f'$ZCURR = {z0:.6f}')
+                        G.shutter('ON')
+                        with G.repeat(col.n_repeat):
+                            G.farcall(wall_filename)
+                            G.instruction(f'$ZCURR = $ZCURR + {col.deltaz / super().neff:.6f}')
+                            G.instruction('LINEAR Z$ZCURR')
+                        G.remove_program(wall_filename)
 
-                    # FLOOR
-                    self.shutter(state='OFF')
-                    self.load_program(floor_path)
-                    self.instruction(f'MSGDISPLAY 1, "COL {col_idx + 1:03}, TR {t_index + 1:03}, LV {nbox + 1:03}, '
-                                     f'F"\n')
-                    if col.u:
-                        self.instruction(f'LINEAR U{col.u[-1]:.6f}')
-                    self.shutter(state='ON')
-                    self.farcall(floor_filename)
-                    self.shutter('OFF')
-                    if col.u:
-                        self.instruction(f'LINEAR U{col.u[0]:.6f}')
-                    self.remove_program(floor_filename)
-            self.instruction('MSGCLEAR -1\n')
+                        # FLOOR
+                        G.shutter(state='OFF')
+                        G.load_program(floor_path)
+                        G.instruction(
+                                f'MSGDISPLAY 1, "COL {col_idx + 1:03}, TR {t_index + 1:03}, LV {nbox + 1:03}, F"\n')
+                        if col.u:
+                            G.instruction(f'LINEAR U{col.u[-1]:.6f}')
+                        G.shutter(state='ON')
+                        G.farcall(floor_filename)
+                        G.shutter('OFF')
+                        if col.u:
+                            G.instruction(f'LINEAR U{col.u[0]:.6f}')
+                        G.remove_program(floor_filename)
+                G.instruction('MSGCLEAR -1\n')
+            del G
 
-            # write instruction to file
-            with open(col_pgm, 'w') as f:
-                f.write(''.join(self._instructions))
-
+        # MAIN FARCALL, calls all columns .pgm scripts
         if self.trench_columns:
-            # farcall main
+            # MAIN FARCALL parameters
             main_param = self._param.copy()
             main_param['filename'] = os.path.join(dirname, 'MAIN.pgm')
+            main_param['aerotech_angle'] = None
+
+            t_list = [os.path.join(col.base_folder, f'FARCALL{idx + 1:03}.pgm') for idx, col in
+                      enumerate(self.trench_columns)]
             with PGMCompiler(main_param) as G:
                 G.chiamatutto(t_list)
 
-    def _export_path(self, filename: str, trench: Trench, f: float = 4):
+    def _export_path(self, filename: str, trench: Trench, speed: float = 4):
         """
         Helper function for the export of the wall and floor instruction of a Trench obj.
 
@@ -632,8 +664,8 @@ class PGMTrench(PGMCompiler):
         :type filename: str
         :param trench: Trench obj to export.
         :type trench: Trench
-        :param f: Traslation speed during fabrication [mm/s]. The default is 4 [mm/s].
-        :type f: float
+        :param speed: Traslation speed during fabrication [mm/s]. The default is 4 [mm/s].
+        :type speed: float
         :return: None
         """
         if filename is None:
@@ -641,16 +673,15 @@ class PGMTrench(PGMCompiler):
         if filename.endswith('.pgm'):
             filename = filename.split('.')[0]
 
-        # wall
+        # Wall script
         points = np.array(trench.block.exterior.coords.xy).T
-        f_val = f
-        self._write_array(filename + '_wall.pgm', points, f_val)
+        self._write_array(filename + '_wall.pgm', points, speed)
         del points
 
-        # floor
+        # Floor script
         points = []
         [points.extend(np.stack(path, axis=-1)) for path in trench.trench_paths()]
-        self._write_array(filename + '_floor.pgm', np.array(points), f_val)
+        self._write_array(filename + '_floor.pgm', np.array(points), speed)
         del points
 
     def _write_array(self, pgm_filename: str, points: np.ndarray, f_val: float):

--- a/femto/Parameters.py
+++ b/femto/Parameters.py
@@ -264,14 +264,15 @@ class GcodeParameters:
         self.fwarp = self.antiwarp_management(self.warp_flag)
 
         if self.rotation_angle != 0:
-            print(' BEWARE, ANGLES MUST BE IN DEGREE! '.center(39, "*"))
-            print(f' Given alpha = {self.rotation_angle % 360:.3f} deg. '.center(39, "*"))
+            print(' BEWARE, ANGLE MUST BE IN DEGREE! '.center(39, "*"))
+            print(f' Rotation angle is {self.rotation_angle % 360:.3f} deg. '.center(39, "*"))
         self.rotation_angle = radians(self.rotation_angle % 360)
 
         if self.aerotech_angle:
             print(' BEWARE, G84 COMMAND WILL BE USED!!! '.center(39, "*"))
-            print(' ANGLES MUST BE IN DEGREE! '.center(39, "*"))
-            print(f' Given alpha = {self.aerotech_angle % 360:.3f} deg. '.center(39, "*"))
+            print(' ANGLE MUST BE IN DEGREE! '.center(39, "*"))
+            print(f' Rotation angle is {self.aerotech_angle % 360:.3f} deg. '.center(39, "*"))
+            print()
             self.aerotech_angle = self.aerotech_angle % 360
 
     @property

--- a/femto/Parameters.py
+++ b/femto/Parameters.py
@@ -51,7 +51,6 @@ class WaveguideParameters:
         if self.z_init is None:
             self.z_init = self.depth
 
-
     @property
     def init_point(self):
         if self.y_init is None:
@@ -65,7 +64,7 @@ class WaveguideParameters:
         return [self.x_init, y0, z0]
 
     @property
-    def dx_bend(self) -> float:
+    def dx_bend(self) -> float or None:
         if self.radius is None:
             raise ValueError('Curvature radius is set to None.')
         if self.dy_bend is None:
@@ -73,13 +72,13 @@ class WaveguideParameters:
         return self.sbend_length(self.dy_bend, self.radius)
 
     @property
-    def dx_acc(self) -> float:
+    def dx_acc(self) -> float or None:
         if self.dy_bend is None or self.dx_bend is None or self.int_length is None:
             return None
         return 2 * self.dx_bend + self.int_length
 
     @property
-    def dx_mzi(self) -> float:
+    def dx_mzi(self) -> float or None:
         if self.dy_bend is None or self.dx_bend is None or self.int_length is None or self.arm_length is None:
             return None
         return 4 * self.dx_bend + 2 * self.int_length + self.arm_length
@@ -113,14 +112,15 @@ class WaveguideParameters:
     @staticmethod
     def get_sbend_parameter(dy: float, radius: float) -> tuple:
         """
-        Computes the final angle, and x-displacement for a circular S-bend given the y-displacement dy and curvature
+        Computes the final rotation_angle, and x-displacement for a circular S-bend given the y-displacement dy and
+        curvature
         radius.
 
         :param dy: Displacement along y-direction [mm].
         :type dy: float
         :param radius: Curvature radius of the S-bend [mm].
         :type radius: float
-        :return: (final angle [radians], x-displacement [mm])
+        :return: (final rotation_angle [radians], x-displacement [mm])
         :rtype: tuple
         """
         a = np.arccos(1 - (np.abs(dy / 2) / radius))
@@ -250,7 +250,8 @@ class GcodeParameters:
     warp_flag: bool = False
     n_glass: float = 1.50
     n_environment: float = 1.33
-    angle: float = 0.0
+    rotation_angle: float = 0.0
+    aerotech_angle: float = None
     long_pause: float = 0.5
     short_pause: float = 0.05
     output_digits: int = 6
@@ -260,17 +261,18 @@ class GcodeParameters:
             raise ValueError('Filename is None, set GcodeParameters.filename.')
         self.CWD = os.path.dirname(os.path.abspath(__file__))
 
-        if self.export_dir:
-            if not os.path.exists(self.export_dir):
-                os.makedirs(self.export_dir)
-            self.filename = os.path.join(self.export_dir, self.filename)
-
         self.fwarp = self.antiwarp_management(self.warp_flag)
 
-        if self.angle != 0:
+        if self.rotation_angle != 0:
             print(' BEWARE, ANGLES MUST BE IN DEGREE! '.center(39, "*"))
-            print(f' Given alpha = {self.angle % 360:.3f} deg. '.center(39, "*"))
-        self.angle = radians(self.angle % 360)
+            print(f' Given alpha = {self.rotation_angle % 360:.3f} deg. '.center(39, "*"))
+        self.rotation_angle = radians(self.rotation_angle % 360)
+
+        if self.aerotech_angle:
+            print(' BEWARE, G84 COMMAND WILL BE USED!!! '.center(39, "*"))
+            print(' ANGLES MUST BE IN DEGREE! '.center(39, "*"))
+            print(f' Given alpha = {self.aerotech_angle % 360:.3f} deg. '.center(39, "*"))
+            self.aerotech_angle = self.aerotech_angle % 360
 
     @property
     def xsample(self) -> float:

--- a/femto/Parameters.py
+++ b/femto/Parameters.py
@@ -31,8 +31,7 @@ class WaveguideParameters:
     int_length: float = 0.0
     arm_length: float = 0.0
     speed_closed: float = 75
-    speedpos: float = 0.5
-    dwelltime: float = 0.5
+    speed_pos: float = 0.5
     lsafe: float = 2.0
     ltrench: float = 1.0
     dz_bridge: float = 0.007
@@ -255,6 +254,7 @@ class GcodeParameters:
     long_pause: float = 0.5
     short_pause: float = 0.05
     output_digits: int = 6
+    speed_pos: float = 5.0
 
     def __post_init__(self):
         if self.filename is None:

--- a/femto/Waveguide.py
+++ b/femto/Waveguide.py
@@ -116,9 +116,9 @@ class Waveguide(LaserPath):
         arc of a given radius. The user can set the transition speed, the shutter state during the movement and the
         number of points of the arc.
 
-        :param initial_angle: Starting angle of the circular arc [radians].
+        :param initial_angle: Starting rotation_angle of the circular arc [radians].
         :type initial_angle: float
-        :param final_angle: Ending angle of the circular arc [radians].
+        :param final_angle: Ending rotation_angle of the circular arc [radians].
         :type final_angle: float
         :param radius: Radius of the circular arc [mm]. The default is self.radius.
         :type radius: float
@@ -149,7 +149,7 @@ class Waveguide(LaserPath):
         """
         Concatenates two circular arc to make a circular S-bend.
         The user can specify the amplitude of the S-bend (height in the y direction) and the curvature radius.
-        Starting and ending angle of the two arcs are computed automatically.
+        Starting and ending rotation_angle of the two arcs are computed automatically.
 
         The sign of dy encodes the direction of the S-bend:
             - dy > 0, upward S-bend
@@ -307,7 +307,7 @@ class Waveguide(LaserPath):
         num = self._get_num(dx, f)
 
         new_x = np.linspace(self._x[-1], self._x[-1] + dx, num)
-        new_y = self._y[-1] + 0.5 * dy * (1 - np.cos(2*np.pi / dx * (new_x - self._x[-1])))
+        new_y = self._y[-1] + 0.5 * dy * (1 - np.cos(2 * np.pi / dx * (new_x - self._x[-1])))
         new_z = self._z[-1] * np.ones(new_x.shape)
 
         # update coordinates

--- a/femto/Waveguide.py
+++ b/femto/Waveguide.py
@@ -48,7 +48,7 @@ class Waveguide(LaserPath):
         if self._x.size != 0:
             raise ValueError('Coordinate matrix is not empty. Cannot start a new waveguide in this point.')
         if speedpos is None:
-            speedpos = self.speedpos
+            speedpos = self.speed_pos
 
         f0 = np.asarray(speedpos, dtype=np.float32)
         s0 = np.asarray(0.0, dtype=np.float32)

--- a/femto/__init__.py
+++ b/femto/__init__.py
@@ -29,7 +29,7 @@ __all__ = [
 from .helpers import *
 from .Parameters import WaveguideParameters, TrenchParameters, GcodeParameters
 from .LaserPath import LaserPath
-from .Waveguide import Waveguide
+from .Waveguide import Waveguide, coupler
 from .Marker import Marker
 from .Trench import Trench, TrenchColumn
 from .PGMCompiler import PGMCompiler, PGMTrench

--- a/femto/__init__.py
+++ b/femto/__init__.py
@@ -21,9 +21,9 @@ __all__ = [
     'TrenchColumn',
     'PGMCompiler',
     'PGMTrench',
-    'helpers',
-    'Cell',
     'Device',
+    'Cell',
+    'helpers',
 ]
 
 from .helpers import *
@@ -33,4 +33,4 @@ from .Waveguide import Waveguide
 from .Marker import Marker
 from .Trench import Trench, TrenchColumn
 from .PGMCompiler import PGMCompiler, PGMTrench
-from .Cell import Cell
+from .Cell import Cell, Device

--- a/femto/helpers.py
+++ b/femto/helpers.py
@@ -1,4 +1,5 @@
 from functools import partial
+from itertools import cycle
 from typing import List
 
 
@@ -61,3 +62,7 @@ def flatten(items, seqtypes=(list, tuple)):
     except IndexError:
         pass
     return items
+
+
+def sign():
+    return cycle([1, -1])


### PR DESCRIPTION
Standardize .pgm file compilation. Cell objects instantiate PGMCompiler objects to take advantage of __enter__ and __exit__ methods. 
In this way, axis rotation (G84) can be given and removed safely. 

Axis rotation is implemented using a context manager. It can be specified using a `with` statement as follow:

```python
with PGMCompiler(PARAMETER_GC) as G:
    with G.axis_rotation(angle=1.234):
        ...
        code
        ...
...
```
In this way, it is __automatically__ disabled out of the indented block. Note, angle are specified in degree.